### PR TITLE
Fix BasicArbitrary::id2nodeid causing SEGV on netrace traffic

### DIFF
--- a/src/topologies/basic_arbitrary.h
+++ b/src/topologies/basic_arbitrary.h
@@ -48,7 +48,7 @@ class BasicArbitrary : public System {
 
   // override as simple 1:1
   inline NodeID id2nodeid(int id) const override {
-    int node_id = id;
+    int node_id = 0;
     int chip_id = id;
     return NodeID(node_id, chip_id);
   }


### PR DESCRIPTION
Netrace file is digested by TrafficManager::netrace(), which calls System::id2nodeid(). Current implementation sets both node_id and chip_id to id, while the system contains 1 node each chip, causing SEGV on later simulations. This PR fixes the issue.